### PR TITLE
fix: use acceptor subkey for initiator signing when present. Fixes bodgit/tsig#178

### DIFF
--- a/context.go
+++ b/context.go
@@ -139,6 +139,9 @@ func (ctx *context) MakeSignature(message []byte) ([]byte, error) {
 		if ctx.acceptor {
 			flags |= gssapi.MICTokenFlagAcceptorSubkey
 		}
+	} else if ctx.hasPeerSubkey() {
+		key = ctx.peerSubkey
+		flags |= gssapi.MICTokenFlagAcceptorSubkey
 	}
 
 	token := gssapi.MICToken{


### PR DESCRIPTION
Previously, MakeSignature only checked for the initiator's own subkey
(ctx.subkey) but never used the peer's subkey (ctx.peerSubkey) for
signing.
This caused Windows AD DNS servers to reject GSS-TSIG signed
DNS updates because the signature was computed with the session key
instead of the acceptor's subkey.

Fixes bodgit/tsig#178

I tested this fix by creating a small wrapper using github.com/bodgit/tsig.
Confirmed without the fix, I got the error `unexpected acceptor flag is not set: expecting a token from the acceptor, not in the initiator`
And confirmed with the fix implemented, the DNS record got updated on our Windows DNS server and now error was thrown. 